### PR TITLE
Replace any3 fast

### DIFF
--- a/replace_any3.py
+++ b/replace_any3.py
@@ -33,7 +33,7 @@ def main(xys, inp, out, strID, skip, no_ext):
         
         inp_replaced = s1.replace(xys[0], xys[i]) # Replacing xdd file
         if strID:
-            inp_replaced =  inp_replaced.replace( (strID), f"{i:.{q}d}") # replacing any str IDs
+            inp_replaced =  inp_replaced.replace( (strID), f"{i:.{q}d}") # replacing any strIDs e.g. XXXX
 
         inp_big += '\n' + inp_replaced
         print(xys[i])

--- a/replace_any3.py
+++ b/replace_any3.py
@@ -1,11 +1,10 @@
 #! /usr/bin/env python
 
 import os
-import re
-import sys
+import time
 import argparse
 
-def main(xys, inp, out, strID):
+def main(xys, inp, out, strID, skip, no_ext):
     """[summary]
 
     Args:
@@ -14,25 +13,33 @@ def main(xys, inp, out, strID):
         out ([type]): [description]
     """
 
-    ext =[".xy", ".xye", ".raw"]
-    xys = sorted([f for f in os.listdir(xys) if f.endswith(tuple(ext))])
+    extensions =[".xy", ".xye", ".raw"]
+    if no_ext:
+        xys = sorted([f.split('.')[0] for f in os.listdir(xys) if f.endswith(tuple(extensions))])
+    else:
+        xys = sorted([f for f in os.listdir(xys) if f.endswith(tuple(extensions))])
+
     z, ze = inp, out
 
     if strID:
         q = len(strID)
 
-    for i in range(len(xys)):
+    start = time.time()
+    for i in range(0, len(xys), skip):
 
         fin, fout = open(z), open(ze, 'a+')  
         s1 = fin.read()
 
-        print(f"next : {xys[i]}")
         fout.write( s1.replace (xys[0], xys[i]))
+        print(xys[i])
 
         if strID:
             fout.write( s1.replace( (strID), f"{i:.{q}d}"))
-        fin.close(), fout.close()
 
+    fin.close(), fout.close()
+    end = time.time()
+
+    print(f"Total time: {end-start} seconds")
            
 if __name__ == '__main__':
 
@@ -47,9 +54,15 @@ if __name__ == '__main__':
         help="""Unique string identifier for generating unique variables for each refinement file.
              Ex: stringid = XXXX. Allows to refine unique scale factors. scale_XXXX """)
 
+    parser.add_argument('-no_ext', action="store_true", help="Replace filename in big INP including extension.")
+    parser.add_argument('-skip', nargs="?", default=1, type=int, help="Integer for taking every nth xy file.")
+
     args = parser.parse_args()
     args_dict = vars(args)
 
-    print(args)
-
-    #main()
+    main(args_dict['xys'],
+         args_dict['inp'],
+         args_dict['out'],
+         args_dict['id'],
+         args_dict['skip'],
+         args_dict['no_ext'])

--- a/replace_any3.py
+++ b/replace_any3.py
@@ -31,12 +31,14 @@ def main(xys, inp, out, strID, skip, no_ext):
     for i in range(0, len(xys), skip):
 
         
-        inp_replaced = s1.replace(xys[0], xys[i])
-        inp_big = inp_big + '\n' + inp_replaced
+        inp_replaced = s1.replace(xys[0], xys[i]) # Replacing xdd file
+        if strID:
+            inp_replaced =  inp_replaced.replace( (strID), f"{i:.{q}d}") # replacing any str IDs
+
+        inp_big += '\n' + inp_replaced
         print(xys[i])
 
-        #if strID:
-        #    fout.write( s1.replace( (strID), f"{i:.{q}d}"))
+        
 
     fout.write(inp_big)
     fin.close(), fout.close()

--- a/replace_any3.py
+++ b/replace_any3.py
@@ -25,17 +25,20 @@ def main(xys, inp, out, strID, skip, no_ext):
         q = len(strID)
 
     start = time.time()
+    fin, fout = open(z), open(ze, 'a+')  
+    s1 = fin.read()
+    inp_big = ''
     for i in range(0, len(xys), skip):
 
-        fin, fout = open(z), open(ze, 'a+')  
-        s1 = fin.read()
-
-        fout.write( s1.replace (xys[0], xys[i]))
+        
+        inp_replaced = s1.replace(xys[0], xys[i])
+        inp_big = inp_big + '\n' + inp_replaced
         print(xys[i])
 
-        if strID:
-            fout.write( s1.replace( (strID), f"{i:.{q}d}"))
+        #if strID:
+        #    fout.write( s1.replace( (strID), f"{i:.{q}d}"))
 
+    fout.write(inp_big)
     fin.close(), fout.close()
     end = time.time()
 

--- a/replace_any3.py
+++ b/replace_any3.py
@@ -3,25 +3,53 @@
 import os
 import re
 import sys
+import argparse
 
+def main(xys, inp, out, strID):
+    """[summary]
 
-def main():
+    Args:
+        xys ([type]): [description]
+        inp ([type]): [description]
+        out ([type]): [description]
+    """
 
     ext =[".xy", ".xye", ".raw"]
-    xys = sorted([f for f in os.listdir() if f.endswith(tuple(ext))])
-    z, ze = input("input file (including extension): "), input("output file (including extension): ")
-    h = input("string to replace: ")
-    q = len(h)
+    xys = sorted([f for f in os.listdir(xys) if f.endswith(tuple(ext))])
+    z, ze = inp, out
+
+    if strID:
+        q = len(strID)
+
     for i in range(len(xys)):
 
-        fin, fout = open(z), open(ze, 'a')  
+        fin, fout = open(z), open(ze, 'a+')  
         s1 = fin.read()
 
         print(f"next : {xys[i]}")
         fout.write( s1.replace (xys[0], xys[i]))
-        #fout.write( s1.replace( (h), f"{i:.qd}")) #sort this out later for replacing a string in start.inp with incrementing numbers
+
+        if strID:
+            fout.write( s1.replace( (strID), f"{i:.{q}d}"))
         fin.close(), fout.close()
 
            
 if __name__ == '__main__':
-    main()
+
+    parser = argparse.ArgumentParser(description="Program for making Topas surface refinements.")
+
+    parser.add_argument("xys", type=str, help="Directory of xy files to be refined.")
+    parser.add_argument("inp", type=str, help="Path to start .INP file.")
+    parser.add_argument("out", type=str, help="Path to store Topas .OUT file")
+    parser.add_argument(
+        "-id",
+        type=str, 
+        help="""Unique string identifier for generating unique variables for each refinement file.
+             Ex: stringid = XXXX. Allows to refine unique scale factors. scale_XXXX """)
+
+    args = parser.parse_args()
+    args_dict = vars(args)
+
+    print(args)
+
+    #main()


### PR DESCRIPTION
Replace_any3 is now significantly faster (approx. 75x) due to better IO stream handling i.e. not using .write() hundreds of times.
In additions replace_any3 now comes with a proper CLI. From the command line simply type:

```
python replace_any3.py -h
```
For instructions on how to use the CLI.